### PR TITLE
Remove unused mongoUrl parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .env
+.idea

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ export default buildConfig({
       callbackPath: `/oidc/callback`,
       callbackURL: `${process.env.SELF_URL}/oidc/callback`,
       scope: 'openid offline_access profile email custom_data',
-      mongoUrl: process.env.DATABASE_URI,
       components: {
         Button: SignInButton, //can be your own custom component
         position: "beforeLogin" //beforeLogin | afterLogin
@@ -46,7 +45,7 @@ export default buildConfig({
         slug: Users.slug,
         searchKey: 'email',
       },
-      registerUserIfNotFound: true,
+      createUserIfNotFound: true,
       async userinfo(accessToken) {
         const { data: user } = await axios.get(`${process.env.OIDC_URI}/oidc/me`, {
           headers: {
@@ -83,5 +82,3 @@ To get it running:
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.
-
-[link-contributors]: ../../contributors

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,6 @@ import type { ComponentType } from 'react';
 export const _strategy = 'oauth2';
 
 export interface oidcPluginOptions extends StrategyOptions {
-  /** How to connect to the Mongo database? */
-  mongoUrl: string;
-
   /** Register user after successful authentication (when user not found) - Defaults to false */
   createUserIfNotFound: boolean;
 


### PR DESCRIPTION
The `mongoUrl` parameter is not used by this plugin and can therefore be removed.

Additionally, I found that the example uses an outdated parameter, so I updated that as well.

Closes #2